### PR TITLE
Add hover overlay to reflect pen/eraser position

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
             <button onclick="toggleEraser()" style="background-color: white;">✒️</button>
             <button onclick="clearCanvas()">⛔</button>
         </div>
+        <div id="hoverOverlay"></div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ const drawModeButtons = document.getElementById("drawModeButtons");
 const toggleDrawModeButton = document.getElementById("toggleDrawMode");
 const toggleTaskModeButton = document.getElementById("toggleTaskMode");
 const chalkWidthDisplay = document.getElementById("chalkWidthDisplay");
+const hoverOverlay = document.getElementById("hoverOverlay");
 let isChalkFont = true;
 let isDrawing = false;
 let isErasing = false;
@@ -146,6 +147,7 @@ drawingCanvas.addEventListener("mousemove", (e) => {
             context.stroke();
         }
     }
+    updateHoverOverlay(e);
 });
 
 drawingCanvas.addEventListener("mouseup", () => {
@@ -154,7 +156,20 @@ drawingCanvas.addEventListener("mouseup", () => {
 
 drawingCanvas.addEventListener("mouseout", () => {
     isDrawing = false;
+    hoverOverlay.style.display = "none";
 });
+
+drawingCanvas.addEventListener("mouseover", () => {
+    hoverOverlay.style.display = "block";
+});
+
+function updateHoverOverlay(e) {
+    const rect = drawingCanvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    hoverOverlay.style.left = `${x}px`;
+    hoverOverlay.style.top = `${y}px`;
+}
 
 // Toggle eraser
 function toggleEraser() {

--- a/script.js
+++ b/script.js
@@ -167,8 +167,8 @@ function updateHoverOverlay(e) {
     const rect = drawingCanvas.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
-    hoverOverlay.style.left = `${x}px`;
-    hoverOverlay.style.top = `${y}px`;
+    hoverOverlay.style.left = `${x - chalkWidth / 2}px`;
+    hoverOverlay.style.top = `${y - chalkWidth / 2}px`;
 }
 
 // Toggle eraser

--- a/style.css
+++ b/style.css
@@ -257,4 +257,5 @@ button.eraser-button {
     border-radius: 50%;
     pointer-events: none;
     display: none;
+    transform: translate(-50%, -50%);
 }

--- a/style.css
+++ b/style.css
@@ -247,3 +247,14 @@ button.eraser-button {
     cursor: pointer;
     border-radius: 8px;
 }
+
+/* Hover overlay */
+#hoverOverlay {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    pointer-events: none;
+    display: none;
+}


### PR DESCRIPTION
Add a hover overlay to reflect where the pen/eraser will be applied when the mouse is clicked.

* **index.html**
  - Add a new `div` element with id `hoverOverlay` inside the `chalkboard` div.

* **script.js**
  - Add a constant `hoverOverlay` to reference the new `div` element.
  - Add event listeners to update the position of `hoverOverlay` based on mouse movements over `drawingCanvas`.
  - Normalize cursor position using `getBoundingClientRect()` to ensure consistent behavior across browsers.
  - Add event listeners to show and hide the `hoverOverlay` when the mouse enters and leaves the `drawingCanvas`.

* **style.css**
  - Add CSS styles for `#hoverOverlay` to make it visible and styled appropriately.
