### PR TITLE
Fix hover overlay alignment for pen/eraser

### DIFF
--- a/script.js
+++ b/script.js
@@ -167,8 +167,8 @@ function updateHoverOverlay(e) {
     const rect = drawingCanvas.getBoundingClientRect();
     const x = e.clientX - rect.left;
     const y = e.clientY - rect.top;
-    hoverOverlay.style.left = `${x}px`;
-    hoverOverlay.style.top = `${y}px`;
+    hoverOverlay.style.left = `${x - chalkWidth / 2}px`;
+    hoverOverlay.style.top = `${y - chalkWidth / 2}px`;
 }
 
 // Toggle eraser

--- a/style.css
+++ b/style.css
@@ -257,4 +257,5 @@ button.eraser-button {
     border-radius: 50%;
     pointer-events: none;
     display: none;
+    transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
Update the hover overlay to accurately reflect the drawing position on the drawboard.

* Modify `updateHoverOverlay` function in `script.js` to account for the actual drawing position on the canvas by adjusting the overlay position with chalk width.
* Adjust `#hoverOverlay` styles in `style.css` to ensure proper alignment with the drawing position by adding a transform property.

