### PR TITLE
Add hover overlay to indicate pen/eraser position

### DIFF
--- a/hoverOverlay.js
+++ b/hoverOverlay.js
@@ -1,0 +1,22 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const hoverOverlay = document.getElementById("hoverOverlay");
+
+    function updateHoverOverlay(e) {
+        hoverOverlay.style.left = `${e.offsetX}px`;
+        hoverOverlay.style.top = `${e.offsetY}px`;
+    }
+
+    const drawingCanvas = document.getElementById("drawingCanvas");
+
+    drawingCanvas.addEventListener("mousemove", (e) => {
+        updateHoverOverlay(e);
+    });
+
+    drawingCanvas.addEventListener("mouseout", () => {
+        hoverOverlay.style.display = "none";
+    });
+
+    drawingCanvas.addEventListener("mouseover", () => {
+        hoverOverlay.style.display = "block";
+    });
+});

--- a/index.html
+++ b/index.html
@@ -30,7 +30,9 @@
             <button onclick="toggleEraser()" style="background-color: white;">✒️</button>
             <button onclick="clearCanvas()">⛔</button>
         </div>
+        <div id="hoverOverlay"></div>
     </div>
     <script src="script.js"></script>
+    <script src="hoverOverlay.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ const drawModeButtons = document.getElementById("drawModeButtons");
 const toggleDrawModeButton = document.getElementById("toggleDrawMode");
 const toggleTaskModeButton = document.getElementById("toggleTaskMode");
 const chalkWidthDisplay = document.getElementById("chalkWidthDisplay");
+const hoverOverlay = document.getElementById("hoverOverlay");
 let isChalkFont = true;
 let isDrawing = false;
 let isErasing = false;
@@ -115,6 +116,7 @@ function toggleDrawMode() {
         taskModeControls.style.display = "none";
         drawModeControls.style.display = "block";
         drawModeButtons.style.display = "block";
+        hoverOverlay.style.display = "block";
         toggleDrawModeButton.style.backgroundColor = "#ff5050"; // Change color to red
     } else {
         drawingCanvas.style.display = "none";
@@ -122,6 +124,7 @@ function toggleDrawMode() {
         taskModeControls.style.display = "block";
         drawModeControls.style.display = "none";
         drawModeButtons.style.display = "none";
+        hoverOverlay.style.display = "none";
         toggleDrawModeButton.style.backgroundColor = "#505050"; // Change color back to default
         document.querySelectorAll('.remove-btn').forEach(btn => btn.style.display = 'inline-block'); // Show remove buttons
         loadTasks(); // Ensure tasks are loaded when switching to task mode
@@ -146,6 +149,7 @@ drawingCanvas.addEventListener("mousemove", (e) => {
             context.stroke();
         }
     }
+    updateHoverOverlay(e);
 });
 
 drawingCanvas.addEventListener("mouseup", () => {
@@ -154,6 +158,11 @@ drawingCanvas.addEventListener("mouseup", () => {
 
 drawingCanvas.addEventListener("mouseout", () => {
     isDrawing = false;
+    hoverOverlay.style.display = "none";
+});
+
+drawingCanvas.addEventListener("mouseover", () => {
+    hoverOverlay.style.display = "block";
 });
 
 // Toggle eraser
@@ -187,6 +196,12 @@ function increaseChalkWidth() {
 // Decrease chalk width
 function decreaseChalkWidth() {
     changeChalkWidth(chalkWidth - 1);
+}
+
+// Update hover overlay position and visibility
+function updateHoverOverlay(e) {
+    hoverOverlay.style.left = `${e.offsetX}px`;
+    hoverOverlay.style.top = `${e.offsetY}px`;
 }
 
 // Load initial font and tasks

--- a/style.css
+++ b/style.css
@@ -247,3 +247,14 @@ button.eraser-button {
     cursor: pointer;
     border-radius: 8px;
 }
+
+/* Hover overlay */
+#hoverOverlay {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background-color: rgba(255, 255, 255, 0.5);
+    border-radius: 50%;
+    pointer-events: none;
+    display: none;
+}


### PR DESCRIPTION
Add hover overlay to indicate where the mark will appear on the drawing board.

* **index.html**
  - Add a `div` element with id `hoverOverlay` inside the `chalkboard` div.
  - Add a `script` tag to include the `hoverOverlay.js` file.

* **script.js**
  - Add event listeners for `mousemove`, `mouseout`, and `mouseover` events on the `drawingCanvas` to update the position and visibility of the hover overlay.
  - Create a new function `updateHoverOverlay` to handle the hover overlay's position and visibility.
  - Modify the `toggleDrawMode` function to show/hide the hover overlay based on the current mode.

* **style.css**
  - Add CSS styles for the `hoverOverlay` element to ensure it is always visible in draw mode and styled appropriately.

* **hoverOverlay.js**
  - Create a new file to handle the hover overlay functionality, including updating its position and visibility based on mouse events.

